### PR TITLE
adding OpenBTS style GPRS channel combinations

### DIFF
--- a/Transceiver52M/Transceiver.cpp
+++ b/Transceiver52M/Transceiver.cpp
@@ -445,6 +445,7 @@ void Transceiver::setModulus(size_t timeslot, size_t chan)
   case II:
   case III:
   case FILL:
+  case IGPRS:
     state->fillerModulus[timeslot] = 26;
     break;
   case IV:
@@ -485,6 +486,7 @@ Transceiver::CorrType Transceiver::expectedCorrType(GSM::Time currTime,
   case FILL:
     return IDLE;
     break;
+  case IGPRS:
   case I:
     // TODO: Are we expecting RACH on an IDLE frame?
 /*    if (burstFN % 26 == 25)

--- a/Transceiver52M/Transceiver.h
+++ b/Transceiver52M/Transceiver.h
@@ -132,14 +132,15 @@ public:
     V,                  ///< FCCH+SCH+CCCH+BCCH+SDCCH/4+SACCH/4, uplink RACH+SDCCH/4
     VI,                 ///< CCCH+BCCH, uplink RACH
     VII,                ///< SDCCH/8 + SACCH/8
+    NONE,               ///< Channel is inactive, default
+    LOOPBACK,            ///< similar go VII, used in loopback testing
+    IGPRS,               ///< GPRS channel, like I but static filler frames.
     VIII,               ///< TCH/F + FACCH/F + SACCH/M
     IX,                 ///< TCH/F + SACCH/M
     X,                  ///< TCH/FD + SACCH/MD
     XI,                 ///< PBCCH+PCCCH+PDTCH+PACCH+PTCCH
     XII,                ///< PCCCH+PDTCH+PACCH+PTCCH
     XIII,               ///< PDTCH+PACCH+PTCCH
-    NONE,               ///< Channel is inactive, default
-    LOOPBACK            ///< similar go VII, used in loopback testing
   } ChannelCombination;
 
   /** Codes for burst types of received bursts*/


### PR DESCRIPTION
This is my shot at adding support for GPRS on OpenBTS. The reason for the funny enum ordering is so that it matches up with the ordering that OpenBTS expects (TransceiverRAD1 ordering)
