### PR TITLE
makefile.ma, fixed for external build so that convert.h can be resolv…

### DIFF
--- a/Transceiver52M/UHDDevice.cpp
+++ b/Transceiver52M/UHDDevice.cpp
@@ -121,6 +121,7 @@ static struct uhd_dev_offset uhd_offsets[] = {
 	{ USRP2, 4, 4, 4.6080e-5, "N2XX 4 SPS" },
 	{ B200,  4, 4, B2XX_TIMING_4_4SPS, "B200 4 SPS" },
 	{ B210,  4, 4, B2XX_TIMING_4_4SPS, "B210 4 SPS" },
+	{ X3XX,  4, 4, 5.6567e-5, "X3XX 4 SPS"},
 	{ UMTRX, 4, 4, 5.1503e-5, "UmTRX 4 SPS" },
 	{ LIMESDR, 4, 4, 16.5/GSMRATE, "STREAM/LimeSDR (4 SPS TX/RX)" },
 };

--- a/Transceiver52M/arm/Makefile.am
+++ b/Transceiver52M/arm/Makefile.am
@@ -5,7 +5,7 @@ else
 ARCH_FLAGS = -mfpu=neon
 endif
 
-AM_CFLAGS = -Wall $(ARCH_FLAGS) -std=gnu99 -I../common
+AM_CFLAGS = -Wall $(ARCH_FLAGS) -std=gnu99 -I${srcdir}/../common
 AM_CCASFLAGS = $(ARCH_FLAGS)
 
 noinst_LTLIBRARIES = libarch.la


### PR DESCRIPTION
…ed.  Same thing fixed in commit e476231 for x86.

Literally, the same thing, but in the `arm` directory of `Transceiver52M`.  Stumbled into issue when making a OE bitbake recipe from your (@ttsou) osmo-trx line.  Adding the ${srcdir} just like in the `x86/Makefile.am` fixed the compile error (which was that it couldn't find any of the header files in the `common` directory).